### PR TITLE
Fix LoRA layer import

### DIFF
--- a/gridworld/model/lora.py
+++ b/gridworld/model/lora.py
@@ -1,16 +1,64 @@
 import torch
 import torch.nn as nn
 
-from peft.tuners.lora import LoraLinear
+"""Utility wrapper around the LoRA linear layer.
+
+The upstream ``peft`` library has gone through a few API revisions.  Some
+versions expose the LoRA-augmented linear layer under
+``peft.tuners.lora.LoraLinear`` while newer releases simply call it
+``Linear``.  Older environments might even lack ``peft`` entirely.  The
+training scripts in this repository expect a class compatible with the
+``LoraLinear`` implementation, so we attempt to import it from ``peft`` and
+fall back to a lightweight local implementation if necessary.
+"""
+
+try:  # PEFT >= 0.4
+    from peft.tuners.lora import LoraLinear as _PeftLoraLinear
+except Exception:  # PEFT >= 0.7 uses ``Linear``
+    try:
+        from peft.tuners.lora import Linear as _PeftLoraLinear
+    except Exception:  # PEFT not available -> use simple fallback
+        _PeftLoraLinear = None
+
+import math
 
 
-class LoRALinear(LoraLinear):
-    """Thin wrapper around ``peft.tuners.lora.LoraLinear``.
+if _PeftLoraLinear is None:
+    class _PeftLoraLinear(nn.Linear):
+        """Minimal LoRA linear layer used as a fallback when ``peft`` is missing.
 
-    This project previously shipped a lightweight fallback implementation when
-    ``peft`` was not installed. To simplify the codebase and ensure consistent
-    behavior, the fallback has been removed and ``peft`` is now required.
-    """
+        This implementation supports the ``LoraLinear`` API used in the
+        repository. It simply injects a low-rank update ``BA`` into the base
+        linear layer while keeping the original weights frozen.
+        """
+
+        def __init__(self, in_features, out_features, r=0, lora_alpha=1.0, lora_dropout=0.0, bias=True):
+            super().__init__(in_features, out_features, bias=bias)
+            self.r = r
+            if r > 0:
+                self.lora_A = nn.Linear(in_features, r, bias=False)
+                self.lora_B = nn.Linear(r, out_features, bias=False)
+                self.scaling = lora_alpha / r
+                self.lora_dropout = nn.Dropout(p=lora_dropout)
+                nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
+                nn.init.zeros_(self.lora_B.weight)
+                self.weight.requires_grad = False
+            else:
+                self.lora_A = None
+                self.lora_B = None
+                self.scaling = 0.0
+                self.lora_dropout = nn.Identity()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            result = super().forward(x)
+            if self.r > 0:
+                update = self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
+                result = result + update
+            return result
+
+
+class LoRALinear(_PeftLoraLinear):
+    """Compatibility wrapper used throughout the codebase."""
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- add a fallback `LoRALinear` implementation for environments without `peft`

## Testing
- `python gridworld/train.py --alg-config ./gridworld/cfg/alg/ppo_dr.yaml --env-config ./gridworld/cfg/env/darkroom.yaml --model-config ./gridworld/cfg/model/ad_dr.yaml` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683a05e12000832ea5a34aefc1aaac65