### PR TITLE
Fix LoRA adapter init for PEFT 0.11

### DIFF
--- a/gridworld/model/lora.py
+++ b/gridworld/model/lora.py
@@ -32,7 +32,7 @@ if _PeftLoraLinear is None:
         linear layer while keeping the original weights frozen.
         """
 
-        def __init__(self, in_features, out_features, r=0, lora_alpha=1.0, lora_dropout=0.0, bias=True):
+        def __init__(self, in_features, out_features, r=0, lora_alpha=1.0, lora_dropout=0.0, bias=True, **kwargs):
             super().__init__(in_features, out_features, bias=bias)
             self.r = r
             if r > 0:
@@ -68,6 +68,7 @@ class LoRALinear(_PeftLoraLinear):
         lora_alpha: float = 1.0,
         lora_dropout: float = 0.0,
         bias: bool = True,
+        adapter_name: str = "default",
     ) -> None:
         super().__init__(
             in_features,
@@ -76,5 +77,6 @@ class LoRALinear(_PeftLoraLinear):
             lora_alpha=lora_alpha,
             lora_dropout=lora_dropout,
             bias=bias,
+            adapter_name=adapter_name,
         )
 


### PR DESCRIPTION
## Summary
- ensure our LoRA wrapper passes a string adapter name
- allow extra kwargs in the fallback LoRA class

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683a08d28d94832ea5da1a15c59b489e