### PR TITLE
Add LoRA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ python collect_data.py -ac [algorithm config]  -ec [environment config] -t [traj
 
 To train the model, run:
 ```bash
-python train.py -ac [algorithm config]  -ec [environment config] -mc [model config] -t [trajectory directory] -l [log directory]
+python train.py -ac [algorithm config]  -ec [environment config] -mc [model config] \
+               -t [trajectory directory] -l [log directory]
+```
+
+To enable LoRA fine-tuning, provide the optional `--lora-config` argument:
+```bash
+python train.py -ac [algorithm config]  -ec [environment config] -mc [model config] \
+               --lora-config gridworld/cfg/lora/default.yaml
 ```
 
 ### Evaluation

--- a/gridworld/cfg/lora/default.yaml
+++ b/gridworld/cfg/lora/default.yaml
@@ -1,0 +1,8 @@
+use_lora: true
+lora:
+  r: 8
+  alpha: 32
+  dropout: 0.05
+  bias: "none"
+  target_modules: ["attn.attn", "attn.proj"]
+  task_type: "FEATURE_EXTRACTION"


### PR DESCRIPTION
## Summary
- add default LoRA config
- load optional LoRA configuration in `train.py`
- inject LoRA adapters and save them during training
- update evaluation script to restore LoRA adapters
- document LoRA usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gym')*


------
https://chatgpt.com/codex/tasks/task_e_683a6872b1d8832ea8a4315bfb8b63ed